### PR TITLE
Fix hero title on mobile

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -9,7 +9,7 @@ Copyright © ${new Date().getFullYear()} Quilibrium, Inc. \
 Built with Docusaurus.`
 
 const config: Config = {
-  title: 'Quilibrium Documentation',
+  title: 'Quilibrium Docs',
   tagline: 'Learn how to get started building on the network, run a node or just understand the technology',
   favicon: 'img/favicon.png',
 


### PR DESCRIPTION
This PR changes the site title from "Quilibrium Documentation" to "Quilibrium Docs", as "Documentation" was split into two lines in the hero title on mobile.

Error:

<img width="1072" alt="Screenshot 2024-09-28 at 13 00 18" src="https://github.com/user-attachments/assets/e142922a-9643-4e56-97c4-cbdb4d843ee8">

Fixed:

<img width="1072" alt="Screenshot 2024-09-28 at 13 00 42" src="https://github.com/user-attachments/assets/28ae7e20-ff47-4e08-930a-dbbf35057d64">
