### PR TITLE
Fix site URL configuration

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -16,7 +16,7 @@ const config: Config = {
   favicon: "img/favicon.png",
 
   // Set the production url of your site here
-  url: "https://quilibrium.com",
+  url: "https://docs.quilibrium.com",
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: "/",


### PR DESCRIPTION
Updated the production URL in docusaurus.config.ts from https://quilibrium.com to https://docs.quilibrium.com to match the actual deployment domain. This should resolve trailing slash issues that occurred only in production where URL mismatches caused Docusaurus to normalize URLs by adding trailing slashes, breaking internal links. Should resolve, although not tested.