### PR TITLE
Fix and prevent broken links

### DIFF
--- a/.cursor/rules/q-services-api-docs.mdc
+++ b/.cursor/rules/q-services-api-docs.mdc
@@ -44,7 +44,7 @@ Data Types that have their own files for their documentation should always be li
 
 Data Types should be capitalized, e.g. String, Integer, Boolean
 
-if the type has a data type file, use html to link it, e.g. <a href=\"/docs/api/q-storage/data-types/object\">Object</a>
+if the type has a data type file, use html to link it, e.g. <a href=\"/docs/api/q-storage/api-reference/data-types/object\">Object</a>
 
 When creating Request Syntax, note the `Host:` urls in request syntax are in the format of `<bucket-name>.<service>.quilibrium.com`.  So if the QStorage bucket name as `example-bucket`, the Request Syntax would have `Host: example-bucket.qstorage.quilibrium.com`.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ Please write one sentence per line in the markdown files for easy reviewing.
 
 In addition to the Markdown changes, the PR should explain the motivation for the change and any other information that is necessary for reviewing it.
 
+
+### Links
+
+Docusaurus [supports](https://docusaurus.io/docs/markdown-features/links) two types of links in Markdown: URL paths (e.g. `./installation`) and file paths (`./installation.md`).
+When editing Markdown files in the `docs` directory, prefer to use relative file path links to other documentation files (e.g. `./installation.md`).
+Docusaurus will turn these into absolue URL paths under the hood in the generated HTML, but using relative Markdown paths in the source files has the advantage of links working in Markdown editors, and IDEs with refactoring support can update paths automatically when things are moved around.
+
 ## UI Development
 
 This website is built using [Docusaurus](https://docusaurus.io/), a modern static website generator.

--- a/docs/api/03-q-storage/02-api-reference/01-bucket-operations/get-bucket-encryption.md
+++ b/docs/api/03-q-storage/02-api-reference/01-bucket-operations/get-bucket-encryption.md
@@ -43,7 +43,7 @@ export const RESPONSE_BODY_ELEMENTS = [
   },
   {
     name: "Rule",
-    type: "<a href=\"/docs/api/q-storage/data-types/server-side-encryption-rule\">ServerSideEncryptionRule</a>",
+    type: "<a href=\"/docs/api/q-storage/api-reference/data-types/server-side-encryption-rule\">ServerSideEncryptionRule</a>",
     description: "Container for a server-side encryption rule. The bucket encryption configuration can include only one rule.",
     required: true
   }

--- a/docs/api/03-q-storage/02-api-reference/01-bucket-operations/get-bucket-lifecycle.md
+++ b/docs/api/03-q-storage/02-api-reference/01-bucket-operations/get-bucket-lifecycle.md
@@ -43,7 +43,7 @@ export const RESPONSE_ELEMENTS = [
   },
   {
     name: "Rule",
-    type: "<a href=\"/docs/api/q-storage/data-types/rule\">Rule</a>",
+    type: "<a href=\"/docs/api/q-storage/api-reference/data-types/rule\">Rule</a>",
     description: "Container for a lifecycle rule. The bucket can have zero or more lifecycle rules.",
     required: true
   }
@@ -183,7 +183,7 @@ This operation does not have a request body.
 
 <ParamsTable parameters={RESPONSE_ELEMENTS} type="response" />
 
-For details about the elements within the Rule type, see <a href="/docs/api/q-storage/data-types/rule">Rule</a>. The response format follows the [AWS S3 GetBucketLifecycle API](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLifecycle.html) specification.
+For details about the elements within the Rule type, see <a href="/docs/api/q-storage/api-reference/data-types/rule">Rule</a>. The response format follows the [AWS S3 GetBucketLifecycle API](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLifecycle.html) specification.
 
 ## Special Errors
 

--- a/docs/api/03-q-storage/02-api-reference/01-bucket-operations/get-bucket-metadata-table-configuration.md
+++ b/docs/api/03-q-storage/02-api-reference/01-bucket-operations/get-bucket-metadata-table-configuration.md
@@ -48,7 +48,7 @@ export const responseElements = [
   {
     name: 'MetadataTableConfigurationResult',
     description: 'The metadata table configuration for a general purpose bucket',
-    type: '<a href="../data-types/metadata-table-configuration-result">MetadataTableConfigurationResult</a>',
+    type: '<a href="/docs/api/q-storage/api-reference/data-types/metadata-table-configuration-result">MetadataTableConfigurationResult</a>',
     required: true
   },
   {
@@ -60,7 +60,7 @@ export const responseElements = [
   {
     name: 'Error',
     description: 'Contains error information if the table creation fails',
-    type: '<a href="../data-types/error-details">ErrorDetails</a>',
+    type: '<a href="/docs/api/q-storage/api-reference/data-types/error-details">ErrorDetails</a>',
     required: false
   }
 ];

--- a/docs/api/03-q-storage/02-api-reference/01-bucket-operations/put-bucket-lifecycle-configuration.md
+++ b/docs/api/03-q-storage/02-api-reference/01-bucket-operations/put-bucket-lifecycle-configuration.md
@@ -139,7 +139,7 @@ By default, all QStorage objects are persistently stored; however, you can use o
 
 <ParamsTable parameters={REQUEST_ELEMENTS} type="request" />
 
-For details about the elements within the Rule type, see <a href="/docs/api/q-storage/data-types/rule">Rule</a>.
+For details about the elements within the Rule type, see <a href="/docs/api/q-storage/api-reference/data-types/rule">Rule</a>.
 
 ## Examples
 

--- a/docs/api/03-q-storage/02-api-reference/01-bucket-operations/put-bucket-lifecycle.md
+++ b/docs/api/03-q-storage/02-api-reference/01-bucket-operations/put-bucket-lifecycle.md
@@ -124,7 +124,7 @@ By default, all QStorage objects are persistently stored; however, you can use o
 
 <ParamsTable parameters={REQUEST_ELEMENTS} type="request" />
 
-For details about the elements within the Rule type, see <a href="/docs/api/q-storage/data-types/rule">Rule</a>.
+For details about the elements within the Rule type, see <a href="/docs/api/q-storage/api-reference/data-types/rule">Rule</a>.
 
 ## Examples
 

--- a/docs/api/03-q-storage/02-api-reference/09-data-types/object.md
+++ b/docs/api/03-q-storage/02-api-reference/09-data-types/object.md
@@ -39,7 +39,7 @@ export const OBJECT_PROPERTIES = [
   },
   {
     name: "Owner",
-    type: "<a href=\"/docs/api/q-storage/data-types/owner\">Owner</a>",
+    type: "<a href=\"/docs/api/q-storage/api-reference/data-types/owner\">Owner</a>",
     description: "The owner of the object",
     required: false
   },

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -32,8 +32,17 @@ const config: Config = {
   organizationName: "QuilibriumNetwork", // Usually your GitHub org/user name.
   projectName: "docs", // Usually your repo name.
 
+  // Fail the build for broken anchor (e.g. `/broken-link#anchor`) declared with 
+  // the Heading component of Docusaurus.
+  onBrokenAnchors: "throw",
+  // Fail the build for broken links (e.g. `./broken-link`)
   onBrokenLinks: "throw",
-  onBrokenMarkdownLinks: "warn",
+  // Fail the build for broken markdown links. Note that this only applies to links 
+  // that have `.md` or `.mdx` extensions.
+  onBrokenMarkdownLinks: "throw",
+  // Applies to duplicate routes created with the `@docusaurus/plugin-content-pages` 
+  // plugin.
+  onDuplicateRoutes: 'throw',
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -44,6 +44,12 @@ const config: Config = {
   // plugin.
   onDuplicateRoutes: 'throw',
 
+  // Make Docusaurus add a trailing slash to the URLs so that links like `/docs/foo` 
+  // will be rewritten to `/docs/foo/`.
+  // This is necessary to make the local environment match the production environment 
+  // as GitHub Pages that adds trailing slashes to URLs unless they have an extension.
+  trailingSlash: true,
+
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you
   // may want to replace "en" with "zh-Hans".

--- a/hyperlink.sh
+++ b/hyperlink.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Wrapper script for hyperlink CLI tool
+# First tries to run hyperlink directly if available on PATH
+# Falls back to npx on supported platforms, otherwise shows cargo install instructions
+
+is_supported_platform() {
+    local arch=$(uname -m)
+    local os=$(uname -s)
+
+    case "$os" in
+        Darwin)
+            # MacOS (both Intel and ARM)
+            return 0
+            ;;
+        CYGWIN*|MINGW*|MSYS*)
+            # Windows
+            return 0
+            ;;
+        Linux)
+            # Only x86 Linux is supported by npm package
+            if [[ "$arch" == "x86_64" ]]; then
+                return 0
+            else
+                return 1
+            fi
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+main() {
+    # First, try to use hyperlink if it's available on PATH
+    if command -v hyperlink >/dev/null 2>&1; then
+        exec hyperlink "$@"
+    fi
+
+    # If not available, check if we can use npx
+    if is_supported_platform; then
+        exec npx @untitaker/hyperlink "$@"
+    else
+        echo "Error: hyperlink not found and npm package not available for this platform."
+        echo "Please install it with: cargo install --locked hyperlink"
+        echo "Make sure you have Rust/Cargo installed first."
+        exit 1
+    fi
+}
+
+main "$@"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "USE_SIMPLE_CSS_MINIFIER=true docusaurus build",
+    "postbuild": "./hyperlink.sh --check-anchors build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/src/docs/discover/communication/MixnetRouting.tsx
+++ b/src/docs/discover/communication/MixnetRouting.tsx
@@ -20,7 +20,7 @@ const MixnetRouting = () => {
         <li><b>Internal, Passive</b> – the attacker operates as a normal mixnet node to decrypt one or more hops of the traffic.</li>
       </ul>
       <p className="py-4 text-justify">
-        Our approach to solving these problems is through economic <Link to="/docs/discover/operating-system/universal-resources">disincentives</Link> making it too expensive to broadly interrupt traffic flow at the external active attacker level, our direct routing strategy through RPM detailed further below to completely make the internal active/passive attacker models fail, as they would identify the bad actor through protocol aborts, and finally through our gossip layer <Link to="/docs/communication/gossip">BlossomSub</Link> to make the external passive model infeasible.
+        Our approach to solving these problems is through economic <Link to="/docs/learn/operating-system/universal-resources">disincentives</Link> making it too expensive to broadly interrupt traffic flow at the external active attacker level, our direct routing strategy through RPM detailed further below to completely make the internal active/passive attacker models fail, as they would identify the bad actor through protocol aborts, and finally through our gossip layer <Link to="/docs/learn/communication/p2p-communication">BlossomSub</Link> to make the external passive model infeasible.
       </p>
       <h2 className="text-xl pt-10 pb-4 font-medium">RPM</h2>
       <p className="pb-4 text-justify">
@@ -85,7 +85,7 @@ const MixnetRouting = () => {
       </div>
       <h2 className="text-xl pt-10 pb-4 font-medium">Broadcast</h2>
       <p className="pb-4 text-justify">
-        All messages are broadcast, to be retrieved by their intended recipients, following <Link to="/docs/communication/gossip">BlossomSub</Link>.
+        All messages are broadcast, to be retrieved by their intended recipients, following <Link to="/docs/learn/communication/p2p-communication">BlossomSub</Link>.
       </p>
       <h2 className="text-xl pt-10 pb-4 font-medium">Processing/Acknowledgement</h2>
       <p className="pb-4 text-justify">

--- a/src/docs/discover/oblivious-hypergraph/RDFStorage.tsx
+++ b/src/docs/discover/oblivious-hypergraph/RDFStorage.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 const RDFStorage = () => {
   return <div className="learn-page text-left flex md:flex-row flex-col text-slate">
     <div className="flex-1">
-      <p className="text-justify">The construction is described in the paper <a href="https://ieeexplore.ieee.org/document/7218100/">"Hypergraph Based Query Optimization"</a>, which we will use by translating the logic to OT circuits, starting with decryption into the circuit using the extended decryption process of the address content. We adopt their term definitions in this section, <Link to="/docs/hypergraph/queryplanner">Query Planner</Link>, and <Link to="/docs/hypergraph/queryevaluator">Query Evaluator</Link>. their definitions provided here roughly verbatim for convenience:</p>
+      <p className="text-justify">The construction is described in the paper <a href="https://ieeexplore.ieee.org/document/7218100/">"Hypergraph Based Query Optimization"</a>, which we will use by translating the logic to OT circuits, starting with decryption into the circuit using the extended decryption process of the address content. We adopt their term definitions in this section, <Link to="/docs/learn/oblivious-hypergraph/query-planner">Query Planner</Link>, and <Link to="/docs/learn/oblivious-hypergraph/query-evaluator">Query Evaluator</Link>. their definitions provided here roughly verbatim for convenience:</p>
       <div className="p-6 my-6 block rounded-xl dark:bg-white/10 bg-pink-50 drop-shadow-xl font-['ui-serif']">
         <div>Notation:</div>
         <ol className="list-decimal pl-6">


### PR DESCRIPTION
This PR includes a fix for broken links and adds measures to prevent them in the future. I also added a section in the readme with a recommendation on links in Markdown doc files.

## Broken relative link

### Root cause

In [db35eb](https://github.com/QuilibriumNetwork/docs/commit/db35eb74783fe8d1761d8da0e927d44a196917eb#diff-5ba434bd6245e03e7dfb24ee5845e9bbfc2a2bec495ed5ba50148f90a2cfe71fR59-R61) two broken links were added to `docs/protocol/overview.md` by accident: 

```md
Explore the specific protocol components in detail:
- [Consensus Mechanism](./consensus) - How the network reaches agreement
- [Data Structures](./data-structures) - How information is organized and stored
``` 

In the generated HTML these relative links were turned into absolute paths by Docusaurus:

```html
<a href="/docs/protocol/consensus">Consensus Mechanism</a> 
<a href="/docs/protocol/data-structures">Data Structures</a>
```

But in the JS configuration of the client side React router they were relative paths:

```js
{href:"./consensus",children:"Consensus Mechanism"}
{href:"./data-structures",children:"Data Structures"}
```

This works fine when testing locally, because the browser path for `docs/protocol/overview.md` is `/docs/protocol/overview`, so the relative link in React router is resolved relative to `/docs/protocol` resulting in the valid path `/docs/protocol/consensus`.

But when visiting `https://docs.quilibrium.com/docs/protocol/overview`, Github Pages redirects to `/docs/protocol/overview/` (note the trailing slash). So in production, the relative link `./consensus` got resolved relative to `/docs/protocol/overview/` which resulted in the invalid path `/docs/protocol/overview/consensus`.

### Resolution

The broken links were fixed before this PR in https://github.com/QuilibriumNetwork/docs/commit/1f0b770a67b97f791ffc0ca468d165ed5d759fd5 and the fix has been deployed already.

### Prevention

We can prevent broken relative links in React router by enabling the [trailingSlash](https://docusaurus.io/docs/api/docusaurus-config#trailingSlash) config option in the Docusaurus. This will add a trailing slash to every link in the docs and this will trigger Docusaurus's broken link detection for this scenario.

For example, after setting `trailingSlash: true`, and with  `[Consensus Mechanism](./consensus)` in `docs/protocol/overview.md`, we get the following error when running `yarn build`:

```
  Exhaustive list of all broken links found:
  - Broken link on source page path = /docs/protocol/overview/:
     -> linking to ./consensus/ (resolved as: /docs/protocol/overview/consensus/)
```

## Broken link in dynamically generated HTML

### Root cause

Docusaurus broken link detection doesn't work for HTML that is dynamically generated by React components. This caused some broken links from TSX components go undetected.

### Resolution

I fixed these broken links in the commit https://github.com/QuilibriumNetwork/docs/commit/e172b75535a514fbdc457eab1ec64f4519971818 that is part of this PR.

### Prevention

I added the [hyperlink](https://github.com/untitaker/hyperlink) broken link checker as a post build step. This will make `yarn build` fail with an error message like this if a broken link is detected:

```
build/docs/learn/communication/mixnet-routing/index.html
  error: bad link /docs/learn/communication/communication
```
