### PR TITLE
Enhance the "key" section of advanced configuraiton page

### DIFF
--- a/docs/run-node/advanced-configuration.md
+++ b/docs/run-node/advanced-configuration.md
@@ -18,14 +18,14 @@ The key section specifies the key provider configuration:
 
 ```
 key:
-  keyManagerType: file | mem – Key manager the node should use (refer to the following section for the `file` key manager configuration)
+  keyManagerType: file – Key manager the node should use
   keyManagerFile:
     path: .config/keys.yml | <string> – Path to key file
     createIfMissing: false | true – If true, the node will (re-)create the missing key file
     encryptionKey: <hex string> – Hexadecimal encryption key (without 0x prefix)
 ```
 
-By default, the file-based key manager is specified. Support for PKCS11 and RPC will be enabled in a subsequent upgrade.
+By default, the file-based key manager is specified. Support for in-memory, PKCS11 and RPC will be enabled in a subsequent upgrade.
 
 ## Peer-to-Peer Networking Section
 


### PR DESCRIPTION
2.1 does not yet support in-memory, RPC and PKCS11 key manager types.
At the same time, the supported configuration parameter lack descriptions.