### PR TITLE
Optimize "Key and Store Backups" section in Quick Start page

### DIFF
--- a/docs/run-node/quick-start.md
+++ b/docs/run-node/quick-start.md
@@ -66,9 +66,11 @@ This script is intended to help get started quickly, but for robust deployments 
 
 ## Key and Store Backups
 
-In order to run a node, access rewards or make token operations for your account, you need the node's **keyset** consisting of the `config.yml` and `keys.yml` files. You are strongly advised to maintain copies of these files in encypted backup.
+In order to run a node, access rewards or make token operations for your account, you need the node's **keyset** consisting of the `config.yml` and `keys.yml` files. You are strongly advised to maintain copies of these files in an encrypted backup.
 
 **Worker data** is stored in `worker-store/[worker-id]`. It should also be regularly backed up, to make the node restoration faster (for example, in case of physical server failure) and avoid unnecessary penalties.
+
+If this worker data is lost, it can be restored by running the node which will fetch the data from it's shard peers, but will result in missed rewards and penalties if the worker data is not restored in time.
 
 Keyset and worker data are stored in your node's `.config` directory:
 


### PR DESCRIPTION
- Reduced the number of words while prioritizing clarity and term usage consistency
- Wrapped the `.config` directory location hints into the Note formatting